### PR TITLE
Add maskShape parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ The color behind the image. This color will also be used when there are gaps/emp
 
 The shape of the cropping path.
 
+### maskShape
+
+The shape of the UI masking.
+
 ### cropPercentage
 
 How big the crop should be in regards to the width and height available to the cropping widget.


### PR DESCRIPTION
Add an option to decouple the cropping and the UI masking shape, e.g. visually a circle mask is shown, but for cropping a square path is used.

`maskShape`